### PR TITLE
Fixed Jsonify Syntax (returns proper values)

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -27,6 +27,11 @@ def configure_routes(app):
         data = [[famrel], [Medu], [Fedu], [studytime], [goout]]
         query_df = pd.DataFrame({'goout': pd.Series(goout), 'famrel': pd.Series(
             famrel), 'Medu': pd.Series(Medu), 'Fedu': pd.Series(Fedu), 'studytime': pd.Series(studytime)})
-        query = pd.get_dummies(query_df)
-        prediction = clf.predict(query)
-        return jsonify(np.ndarray.item(prediction))
+        #query = pd.get_dummies(query_df)
+        #prediction = clf.predict(query_df)
+        #return jsonify(prediction)#jsonify(np.ndarray(prediction).toList())
+        
+        prediction = list(clf.predict(query_df))[0]
+
+        # Converting to int from int64
+        return jsonify({"prediction": int(prediction)})

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -19,15 +19,14 @@ def configure_routes(app):
     @app.route('/predict')
     def predict():
         #use entries from the query string here but could also use json
-        age = request.args.get('age')
-        absences = request.args.get('absences')
-        health = request.args.get('health')
-        data = [[age], [health], [absences]]
-        query_df = pd.DataFrame({
-            'age': pd.Series(age),
-            'health': pd.Series(health),
-            'absences': pd.Series(absences)
-        })
+        famrel = request.args.get('famrel')
+        Medu = request.args.get('Medu')
+        Fedu = request.args.get('Fedu')
+        studytime = request.args.get('studytime')
+        goout = request.args.get('goout')
+        data = [[famrel], [Medu], [Fedu], [studytime], [goout]]
+        query_df = pd.DataFrame({'goout': pd.Series(goout), 'famrel': pd.Series(
+            famrel), 'Medu': pd.Series(Medu), 'Fedu': pd.Series(Fedu), 'studytime': pd.Series(studytime)})
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)
         return jsonify(np.ndarray.item(prediction))

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,5 +1,6 @@
 from flask import Flask, json
 from app.handlers.routes import configure_routes
+from flask import Flask, jsonify, request
 
 
 def test_base_route():
@@ -13,18 +14,20 @@ def test_base_route():
     assert response.status_code == 200
     assert response.get_data() == b'try the predict route it is great!'
 
-def test_predict_route_accurate():
+
+def test_predict_route_consistent():
     app = Flask(__name__)
     configure_routes(app)
     client = app.test_client()
+
     url = '/predict'
-
-    countSuccess = 0
-    for i in range(1,11):
-        student = {'studytime': abs(min(4, i-2)), 'failures': max(0,min(7,i)-5), 'G3': 10+i}
-        response = client.get(url, data=json.dumps(
-            student), content_type='application/json')
-
-        if (response.status == 200): countSuccess += 1
-    assert countSuccess >= 9
+    famrel = 4
+    Medu = 4
+    Fedu = 4
+    studytime = 4
+    goout = 1
+    student = f'famrel={famrel}&Medu={Medu}&Fedu={Fedu}&studytime={studytime}&goout={goout}'
+    response = client.get(url, query_string=student)
+    assert response.status_code == 200
+    assert response.get_data() == b'{"prediction":0}\n'
     


### PR DESCRIPTION
Fixed issues with internal server error when running prediction. When predict route is called returns b'{"prediction":0} or b'{"prediction":1}